### PR TITLE
Fix entry point for Render deployment

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "backend",
   "version": "1.0.0",
   "type": "module",
-  "main": "index.js",
   "scripts": {
+    "start": "node src/index.js",
     "dev": "node src/index.js"
   },
   "keywords": [],


### PR DESCRIPTION
## Summary
- add a `start` script in `package.json`
- remove the incorrect `main` entry

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_683fb2953a8c832a926beef2a8c67241